### PR TITLE
Add json references to calibration schemas

### DIFF
--- a/regenerate.cmd
+++ b/regenerate.cmd
@@ -1,1 +1,0 @@
-python src/DataSchemas/regenerate.py

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -1,0 +1,12 @@
+Write-Output "Creating a Python environment..."
+if (Test-Path -Path ./.venv) {
+    Remove-Item ./.venv -Recurse -Force
+}
+&python -m venv ./.venv
+&.venv\Scripts\activate
+Write-Output "Installing python packages..."
+&pip install .
+Write-Output "Creating a Bonsai environment and installing packages..."
+Set-Location ./bonsai
+.\setup.ps1
+Set-Location ../.

--- a/scripts/regenerate.ps1
+++ b/scripts/regenerate.ps1
@@ -1,0 +1,4 @@
+Write-Output "Activating local Python environment..."
+&.venv\Scripts\activate
+Write-Output "Regenerating schemas..."
+&python ./src/DataSchemas/regenerate.py

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -1,0 +1,2 @@
+Write-Output "Running unit tests..."
+python -m unittest

--- a/src/DataSchemas/aind_behavior_services/__init__.py
+++ b/src/DataSchemas/aind_behavior_services/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 from .rig import AindBehaviorRigModel
 from .session import AindBehaviorSessionModel

--- a/src/DataSchemas/aind_behavior_services/calibration/load_cells.py
+++ b/src/DataSchemas/aind_behavior_services/calibration/load_cells.py
@@ -10,7 +10,7 @@ from aind_data_schema.base import AindGeneric
 from aind_data_schema.models.units import MassUnit
 from pydantic import BaseModel, Field
 
-__version__ = "0.1.0"
+__VERSION__ = "0.2.0"
 
 LoadCellChannel = Annotated[int, Field(ge=0, le=7, description="Load cell channel number available")]
 
@@ -56,7 +56,7 @@ class LoadCellsCalibration(CalibrationBase):
     notes: Optional[str] = Field(None, title="Notes")
 
     def calibrate(self, input: Optional[LoadCellsCalibrationInput] = None):
-        return super().calibrate(input)
+        raise NotImplementedError
 
 
 class LoadCellsOperationControl(OperationControlModel):
@@ -72,7 +72,9 @@ class LoadCellsOperationControl(OperationControlModel):
 
 
 class LoadCellsCalibrationModel(RigCalibrationFullModel):
-    schema_version: Literal[__version__] = __version__
-    describedBy: Literal[""] = ""
+    schema_version: Literal[__VERSION__] = __VERSION__
+    describedBy: Literal[
+        "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/load_cells_calibration.json"
+    ] = "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/load_cells_calibration.json"
     operation_control: LoadCellsOperationControl = Field(..., title="Operation control")
     calibration: Optional[LoadCellsCalibration] = Field(None, description="Calibration data")

--- a/src/DataSchemas/aind_behavior_services/calibration/olfactometer.py
+++ b/src/DataSchemas/aind_behavior_services/calibration/olfactometer.py
@@ -7,6 +7,9 @@ from aind_data_schema.models.stimulus import OlfactometerChannelConfig
 from pydantic import Field
 
 
+__VERSION__ = "0.2.0"
+
+
 class HarpOlfactometerChannel(IntEnum):
     """Harp Olfactometer available channel"""
 
@@ -45,7 +48,9 @@ class OlfactometerCalibration(CalibrationBase):
 
 
 class OlfactometerCalibrationModel(RigCalibrationFullModel):
-    schema_version: Literal["0.1.0"] = "0.1.0"
-    describedBy: Literal[""] = ""
+    schema_version: Literal[__VERSION__] = __VERSION__
+    describedBy: Literal[
+        "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/olfactometer_calibration.json"
+    ] = "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/olfactometer_calibration.json"
     operation_control: OlfactometerOperationControl
     calibration: Optional[OlfactometerCalibration] = Field(None, description="Calibration data")

--- a/src/DataSchemas/aind_behavior_services/calibration/water_valve.py
+++ b/src/DataSchemas/aind_behavior_services/calibration/water_valve.py
@@ -11,7 +11,7 @@ from aind_behavior_services.calibration import (
 from pydantic import BaseModel, Field
 from sklearn.linear_model import LinearRegression
 
-__version__ = "0.1.0"
+__VERSION__ = "0.2.0"
 
 PositiveFloat = Annotated[float, Field(gt=0)]
 
@@ -143,7 +143,9 @@ class WaterValveOperationControl(OperationControlModel):
 
 
 class WaterValveCalibrationModel(RigCalibrationFullModel):
-    schema_version: Literal[__version__] = __version__
-    describedBy: Literal[""] = ""
+    schema_version: Literal[__VERSION__] = __VERSION__
+    describedBy: Literal[
+        "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/water_valve_calibration.json"
+    ] = "https://raw.githubusercontent.com/AllenNeuralDynamics/Aind.Behavior.Services/main/src/DataSchemas/schemas/water_valve_calibration.json"
     operation_control: WaterValveOperationControl
     calibration: Optional[WaterValveCalibration] = Field(None, description="Calibration data")


### PR DESCRIPTION
This PR:
- Adds references to the `described_by` field in all calibration schemas
- Adds a `scripts` folder to the repository root where automation scripts will be maintained