### PR TITLE
Feat-support-for-x-enum-names

### DIFF
--- a/src/DataSchemas/aind_behavior_services/__init__.py
+++ b/src/DataSchemas/aind_behavior_services/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 from .rig import AindBehaviorRigModel
 from .session import AindBehaviorSessionModel

--- a/src/DataSchemas/aind_behavior_services/utils.py
+++ b/src/DataSchemas/aind_behavior_services/utils.py
@@ -86,7 +86,7 @@ class CustomGenerateJsonSchema(GenerateJsonSchema):
         elif types == {list}:
             result['type'] = 'array'
 
-        if self.render_xenum_names:
+        if (self.render_xenum_names) and (result['type'] != 'string'):
             result['x-enumNames'] = [screaming_snake_case_to_pascal_case(v.name) for v in schema['members']]
 
         return result

--- a/src/DataSchemas/schemas/aind_manipulator_calibration_rig.json
+++ b/src/DataSchemas/schemas/aind_manipulator_calibration_rig.json
@@ -237,7 +237,14 @@
         4
       ],
       "title": "Axis",
-      "type": "integer"
+      "type": "integer",
+      "x-enumNames": [
+        "None",
+        "Y1",
+        "Y2",
+        "X",
+        "Z"
+      ]
     },
     "AxisConfiguration": {
       "description": "Axis configuration",
@@ -349,7 +356,13 @@
         3
       ],
       "title": "MicrostepResolution",
-      "type": "integer"
+      "type": "integer",
+      "x-enumNames": [
+        "Microstep8",
+        "Microstep16",
+        "Microstep32",
+        "Microstep64"
+      ]
     },
     "MotorOperationMode": {
       "enum": [
@@ -357,7 +370,11 @@
         1
       ],
       "title": "MotorOperationMode",
-      "type": "integer"
+      "type": "integer",
+      "x-enumNames": [
+        "Quiet",
+        "Dynamic"
+      ]
     }
   },
   "properties": {

--- a/src/Extensions/AindManipulatorCalibrationRig.cs
+++ b/src/Extensions/AindManipulatorCalibrationRig.cs
@@ -494,19 +494,19 @@ namespace AindBehaviorServices.AindManipulatorCalibrationRig
     {
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="0")]
-        _0 = 0,
+        None = 0,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="1")]
-        _1 = 1,
+        Y1 = 1,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="2")]
-        _2 = 2,
+        Y2 = 2,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="3")]
-        _3 = 3,
+        X = 3,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="4")]
-        _4 = 4,
+        Z = 4,
     }
 
 
@@ -526,11 +526,11 @@ namespace AindBehaviorServices.AindManipulatorCalibrationRig
     
         private int _stepInterval = 100;
     
-        private MicrostepResolution _microstepResolution = AindBehaviorServices.AindManipulatorCalibrationRig.MicrostepResolution._0;
+        private MicrostepResolution _microstepResolution = AindBehaviorServices.AindManipulatorCalibrationRig.MicrostepResolution.Microstep8;
     
         private int _maximumStepInterval = 2000;
     
-        private MotorOperationMode _motorOperationMode = AindBehaviorServices.AindManipulatorCalibrationRig.MotorOperationMode._0;
+        private MotorOperationMode _motorOperationMode = AindBehaviorServices.AindManipulatorCalibrationRig.MotorOperationMode.Quiet;
     
         private int _maxLimit = 24000;
     
@@ -866,16 +866,16 @@ namespace AindBehaviorServices.AindManipulatorCalibrationRig
     {
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="0")]
-        _0 = 0,
+        Microstep8 = 0,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="1")]
-        _1 = 1,
+        Microstep16 = 1,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="2")]
-        _2 = 2,
+        Microstep32 = 2,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="3")]
-        _3 = 3,
+        Microstep64 = 3,
     }
 
 
@@ -884,10 +884,10 @@ namespace AindBehaviorServices.AindManipulatorCalibrationRig
     {
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="0")]
-        _0 = 0,
+        Quiet = 0,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="1")]
-        _1 = 1,
+        Dynamic = 1,
     }
 
 

--- a/src/aind_manipulator_calibration.bonsai
+++ b/src/aind_manipulator_calibration.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:p1="clr-namespace:AindBehaviorServices.AindManipulatorCalibrationRig;assembly=Extensions"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -297,7 +297,7 @@
                   </Expression>
                   <Expression xsi:type="Subtract">
                     <Operand xsi:type="WorkflowProperty" TypeArguments="p1:Axis">
-                      <Value>_1</Value>
+                      <Value>Y1</Value>
                     </Operand>
                   </Expression>
                   <Expression xsi:type="Combinator">
@@ -525,7 +525,7 @@
                         </Expression>
                         <Expression xsi:type="Subtract">
                           <Operand xsi:type="WorkflowProperty" TypeArguments="p1:Axis">
-                            <Value>_1</Value>
+                            <Value>Y1</Value>
                           </Operand>
                         </Expression>
                         <Expression xsi:type="Combinator">


### PR DESCRIPTION
Add support of x-enumNames in json-schema generation. This allows Bonsai.Sgen to correctly generate enum names for non string enum types.