### PR TITLE
Fix manipulator ordering

### DIFF
--- a/examples/aind_manipulator.py
+++ b/examples/aind_manipulator.py
@@ -36,7 +36,7 @@ calibration_session = AindBehaviorSessionModel(
 )
 
 rig = m.CalibrationRig(
-    harp_manipulator=m.AindManipulatorDevice(port_name="COM4"),
+    manipulator=m.AindManipulatorDevice(port_name="COM4", calibration=calibration_data),
     rig_name="AindManipulatorRig",
 )
 

--- a/src/DataSchemas/aind_behavior_services/__init__.py
+++ b/src/DataSchemas/aind_behavior_services/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 
 from .rig import AindBehaviorRigModel
 from .session import AindBehaviorSessionModel

--- a/src/DataSchemas/aind_behavior_services/calibration/aind_manipulator.py
+++ b/src/DataSchemas/aind_behavior_services/calibration/aind_manipulator.py
@@ -14,9 +14,9 @@ class Axis(IntEnum):
     """Motor axis available"""
 
     NONE = 0
-    Y1 = 1
-    Y2 = 2
-    X = 3
+    X = 1
+    Y1 = 2
+    Y2 = 3
     Z = 4
 
 

--- a/src/DataSchemas/schemas/aind_manipulator_calibration_rig.json
+++ b/src/DataSchemas/schemas/aind_manipulator_calibration_rig.json
@@ -83,16 +83,6 @@
         "axis_configuration": {
           "default": [
             {
-              "axis": 1,
-              "step_acceleration_interval": 100,
-              "step_interval": 100,
-              "microstep_resolution": 0,
-              "maximum_step_interval": 2000,
-              "motor_operation_mode": 0,
-              "max_limit": 24000,
-              "min_limit": -1
-            },
-            {
               "axis": 2,
               "step_acceleration_interval": 100,
               "step_interval": 100,
@@ -104,6 +94,16 @@
             },
             {
               "axis": 3,
+              "step_acceleration_interval": 100,
+              "step_interval": 100,
+              "microstep_resolution": 0,
+              "maximum_step_interval": 2000,
+              "motor_operation_mode": 0,
+              "max_limit": 24000,
+              "min_limit": -1
+            },
+            {
+              "axis": 1,
               "step_acceleration_interval": 100,
               "step_interval": 100,
               "microstep_resolution": 0,
@@ -131,9 +131,9 @@
         },
         "homing_order": {
           "default": [
-            1,
             2,
             3,
+            1,
             4
           ],
           "items": {
@@ -240,9 +240,9 @@
       "type": "integer",
       "x-enumNames": [
         "None",
+        "X",
         "Y1",
         "Y2",
-        "X",
         "Z"
       ]
     },

--- a/src/Extensions/AindManipulatorCalibrationRig.cs
+++ b/src/Extensions/AindManipulatorCalibrationRig.cs
@@ -497,13 +497,13 @@ namespace AindBehaviorServices.AindManipulatorCalibrationRig
         None = 0,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="1")]
-        Y1 = 1,
+        X = 1,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="2")]
-        Y2 = 2,
+        Y1 = 2,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="3")]
-        X = 3,
+        Y2 = 3,
     
         [System.Runtime.Serialization.EnumMemberAttribute(Value="4")]
         Z = 4,


### PR DESCRIPTION
For future reference, @nathan-mars provided the following instructions:


## Hookup reference

| Motor | Axis                                                  | Color        |
|-------|-------------------------------------------------------|--------------|
| 0     | X (lateral)                                           | Blue         |
| 1     | Y1 (forward, "port", motor's left mouse's right)      | Red          |
| 2     | Y2 (forward, "starboard", motor's right mouse's left) | Green        |
| 3     | Z (vertical)                                          | White/Silver |


## Motor wiring pattern

Green (B+)
Green-White (B-)
Red (A+)
Red-White (A-)

## End switch wiring pattern

Blue (GND) 
White (Signal)
Brown (+V)
