### PR TITLE
Adopt the clabe/vr-foraging release-tag-driven CICD pattern

### DIFF
--- a/.github/workflows/aind-behavior-services-cicd.yml
+++ b/.github/workflows/aind-behavior-services-cicd.yml
@@ -1,19 +1,6 @@
 name: aind-behavior-services test suite
 
 on:
-  workflow_dispatch:
-    inputs:
-      bump_type:
-        description: "Version bump type"
-        required: false
-        default: "rc"
-        type: choice
-        options:
-          - rc
-          - patch
-          - minor
-          - major
-          - stable
   pull_request:
   push:
     branches:
@@ -22,6 +9,7 @@ on:
       - release*
   release:
     types: [ published ]
+  workflow_dispatch:
 
 jobs:
   # ╔──────────────────────────╗
@@ -51,7 +39,7 @@ jobs:
         run: uv sync
 
       - name: Run ruff format
-        run: uv run ruff format
+        run: uv run ruff format --check
 
       - name: Run ruff check
         run: uv run ruff check
@@ -59,83 +47,20 @@ jobs:
       - name: Run codespell
         run: uv run codespell --check-filenames
 
-      - name: Run python unit tests
-        run: uv run python -m unittest
+      - name: Run pytest
+        run: uv run pytest
 
       - name: Regenerate json-schema
         run: uv run ./src/_generators/json_schema.py
 
       - name: Check for uncommitted changes
+        shell: bash
         run: |
           git config --global core.safecrlf false
           git diff --exit-code || (echo "Untracked changes found" && exit 1)
 
-  # ╔───────────────────────────────────────────────────────────╗
-  # │    ____ ___ ____ ____    ____      _                      │
-  # │   / ___|_ _/ ___|  _ \  |  _ \ ___| | ___  __ _ ___  ___  │
-  # │  | |    | | |   | | | | | |_) / _ \ |/ _ \/ _` / __|/ _ \ │
-  # │  | |___ | | |___| |_| | |  _ <  __/ |  __/ (_| \__ \  __/ │
-  # │   \____|___\____|____/  |_| \_\___|_|\___|\__,_|___/\___| │
-  # │                                                           │
-  # ╚───────────────────────────────────────────────────────────╝
-  github-rc-release:
-    needs: tests
-    runs-on: ubuntu-latest
-    if: >
-      github.ref == 'refs/heads/main' && github.event_name == 'push' &&
-      github.event.head_commit.author.email !=
-      'github-actions[bot]@users.noreply.github.com'
-    name: Create GitHub pre-release
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - uses: astral-sh/setup-uv@v9.0.0
-        with:
-          enable-cache: true
-
-      - name: Bump pre-release by default
-        # Note: Bumping the rc will fail if the version is not currently an rc
-        # To solve it, we bump the patch and rc atomically
-        shell: bash # interop with win/linux for if statement
-        run: |
-          if uv version --bump rc --dry-run; then
-            uv version --bump rc
-          else
-            uv version --bump rc --bump patch
-          fi
-
-      - name: Regenerate json-schema
-        run: uv run ./src/_generators/json_schema.py
-
-      - name: Commit version
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "Bump version [skip ci]" || echo "No changes to commit"
-          git push origin main
-
-      - name: Get version
-        id: get_version
-        shell: bash # interop with win/linux for if statement
-        run: |
-          version=$(uv run uv version --short)
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.get_version.outputs.version }}
-          name: v${{ steps.get_version.outputs.version }}
-          generate_release_notes: true
-          prerelease: true
-          body: |
-            Automated pre-release v${{ steps.get_version.outputs.version }}
+      - name: Build
+        run: uv build
 
   # ╔─────────────────────────────────────────────────────────────────╗
   # │   ____        _     _ _        ____      _                      │
@@ -145,16 +70,13 @@ jobs:
   # │  |_|    \__,_|_.__/|_|_|\___| |_| \_\___|_|\___|\__,_|___/\___| │
   # │                                                                 │
   # ╚─────────────────────────────────────────────────────────────────╝
-
-  prepare-public-release:
+  prepare-release:
     runs-on: ubuntu-latest
-    name: Prepare files for public release
+    name: Set version from release tag
     needs: tests
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'release' && github.event.action == 'published'
     outputs:
       version: ${{ steps.get_version.outputs.version }}
-      is_prerelease: ${{ steps.check_prerelease.outputs.prerelease }}
-
     steps:
       - uses: actions/checkout@v7
         with:
@@ -165,119 +87,69 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Get target version
+      - name: Extract version from tag
         id: get_version
         shell: bash
         run: |
-          # Use bump type from input (defaults to rc)
-          bump_type="${{ github.event.inputs.bump_type || 'rc' }}"
-          echo "Bumping version with type: $bump_type"
-
-          # Handle version bumping based on type
-          if [[ "$bump_type" == "rc" ]]; then
-            # Handle rc bumping logic (same as in github-rc-release)
-            if uv version --bump rc --dry-run; then
-              uv version --bump rc
-            else
-              uv version --bump rc --bump patch
-            fi
-          else
-            # Handle patch, minor, major, stable
-            uv version --bump $bump_type
-          fi
-
-          release_version=$(uv run uv version --short)
-          echo "version=$release_version" >> $GITHUB_OUTPUT
-          echo "Release version will be: $release_version"
+          version=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "Setting version to: $version"
 
       - name: Validate version format
         run: uv version ${{ steps.get_version.outputs.version }} --dry-run
 
-      - name: Update package version
+      - name: Set version
         run: uv version ${{ steps.get_version.outputs.version }}
 
       - name: Regenerate json-schema
         run: uv run ./src/_generators/json_schema.py
 
-      - name: Commit version changes
+      - name: Build
+        run: uv build
+
+      - name: Upload wheels as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+      - name: Commit version and schema changes
+        shell: bash
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "Set version" || echo "No changes to commit"
-          git tag "v${{ steps.get_version.outputs.version }}"
+          git diff --cached --quiet && echo "No changes to commit" && exit 0
+          git commit -m "Set version ${{ steps.get_version.outputs.version }} and regenerate schemas [skip ci]"
           git push origin main
-          git push origin "v${{ steps.get_version.outputs.version }}"
-
-      - name: Determine if prerelease
-        id: check_prerelease
-        shell: bash
-        run: |
-          version="${{ steps.get_version.outputs.version }}"
-          if [[ "$version" == *"rc"* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.get_version.outputs.version }}
-          name: Release v${{ steps.get_version.outputs.version }}
-          generate_release_notes: true
-          prerelease: ${{ steps.check_prerelease.outputs.prerelease }}
-          body: |
-            Release v${{ steps.get_version.outputs.version }}
-
-            This release was manually triggered.
+          # Move the release tag to point to this new commit.
+          git tag -fa "${{ github.event.release.tag_name }}" -m "${{ github.event.release.tag_name }}"
+          git push origin "${{ github.event.release.tag_name }}" --force
 
   publish-to-pypi:
     runs-on: ubuntu-latest
     name: Publish to PyPI
-    needs: [ tests, prepare-public-release ]
-    if: |
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event_name == 'release' &&
-       github.event.action == 'published' &&
-       !github.event.release.prerelease &&
-       startsWith(github.ref, 'refs/tags/v'))
+    needs: prepare-release
     steps:
-      - uses: actions/checkout@v7
+      - name: Download wheels artifact
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.ref_name
-            }}
+          name: dist
+          path: dist/
 
       - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
-      - name: Verify version consistency (for automatic releases)
-        if: github.event_name == 'release'
-        shell: bash
-        run: |
-          tag_version=$(echo "${{ github.ref_name }}" | sed 's/^v//')
-          package_version=$(uv run uv version --short)
-          if [[ "$tag_version" != "$package_version" ]]; then
-            echo "ERROR: Tag version ($tag_version) doesn't match package version ($package_version)"
-            exit 1
-          fi
-          echo "✅ Version consistency verified: $tag_version"
-
-      - name: Get current version (for manual releases)
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          package_version=$(uv run uv version --short)
-          echo "📦 Publishing version: $package_version"
-
-      - name: Build
-        run: uv build
-
       - name: Publish to PyPI
         run: uv publish --token ${{ secrets.AIND_PYPI_TOKEN }}
+
+      - name: Upload wheels to GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: dist/*
 
   # ╔─────────────────────────╗
   # │   ____                  │
@@ -290,18 +162,27 @@ jobs:
   build-docs:
     name: Build and deploy documentation to GitHub Pages
     runs-on: ubuntu-latest
-    needs: publish-to-pypi
-    if: ${{ !github.event.release.prerelease }}
+    needs: [ tests, prepare-release ]
+    if: |
+      always()
+      && needs.tests.result == 'success'
+      && (needs.prepare-release.result == 'success' || needs.prepare-release.result == 'skipped')
+      && (
+        (github.event_name == 'release' && !github.event.release.prerelease)
+        || github.event_name == 'workflow_dispatch'
+      )
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
-      - name: Install dependencies
+      - name: Install docs group of dependencies
         run: uv sync --group docs
 
       - name: Build MkDocs documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Changelog = "https://github.com/AllenNeuralDynamics/Aind.Behavior.Services/relea
 
 [dependency-groups]
 
-dev = ['ruff', 'codespell', 'jinja2', 'requests', 'pyyaml']
+dev = ['ruff', 'codespell', 'jinja2', 'requests', 'pyyaml', 'pytest']
 
 docs = [
     'mkdocs',

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,7 @@ dependencies = [
 dev = [
     { name = "codespell" },
     { name = "jinja2" },
+    { name = "pytest" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "ruff" },
@@ -67,6 +68,7 @@ requires-dist = [
 dev = [
     { name = "codespell" },
     { name = "jinja2" },
+    { name = "pytest" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "ruff" },
@@ -314,6 +316,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -715,6 +726,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -860,6 +880,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Unifies `aind-behavior-services` CI/CD with the pattern shared by [`clabe`](https://github.com/AllenNeuralDynamics/clabe) and [`Aind.Behavior.VrForaging`](https://github.com/AllenNeuralDynamics/Aind.Behavior.VrForaging). The current workflow uses a bespoke release flow (auto-rc pre-release on every push to `main`, plus a `workflow_dispatch` version-bump path); this replaces it with the shared **release-tag-driven** model.

## Jobs

| Job | Behavior |
|-----|----------|
| **tests** (matrix: ubuntu + windows × py 3.11–3.13) | `uv sync` → `ruff format --check` → `ruff check` → `codespell --check-filenames` → **`pytest`** → regenerate json-schema → check-uncommitted → **`uv build`** |
| **prepare-release** (on GitHub Release `published`) | derive version **from the release tag** → regenerate schemas → build → upload a `dist` artifact → commit the version/schema bump to `main` → move the tag to that commit |
| **publish-to-pypi** | download the artifact → `uv publish` (no rebuild) → attach wheels to the GitHub release |
| **build-docs** | MkDocs `build --strict` + gh-pages, on a non-prerelease release or manual `workflow_dispatch` |

## Behavioral change (please note)

**Releasing is now: publish a GitHub Release with a `vX.Y.Z` tag.** CI sets the package version from the tag, regenerates, builds, publishes to PyPI, and deploys docs.

This **removes**:
- the auto-rc-pre-release-on-every-`main`-push job, and
- the `workflow_dispatch` version-bump inputs (rc/patch/minor/major/stable).

## Other changes

- Test runner switched from `python -m unittest` to `pytest`; `pytest` added to the `dev` dependency group (lockfile updated).
- Docs deploy via MkDocs (following the recent Sphinx→MkDocs migration).
- Kept this repo's newer action pins (`actions/checkout@v7`, `astral-sh/setup-uv@v9.0.0`).

## Validation

Ran the full `tests`-job chain locally — all green: `ruff format --check`, `ruff check`, `codespell --check-filenames`, **pytest (109 passed)**, deterministic json-schema regen (`schema/` unchanged), and `uv build`. Workflow YAML parses to the four jobs above. `dist/` is gitignored, so `prepare-release`'s `git add .` will not commit build artifacts.

## Follow-up to confirm

`prepare-release` pushes the version-bump commit and force-moves the tag to `main` using the default `GITHUB_TOKEN` (matching `clabe` and this repo's existing bot pushes). If `main` has a branch ruleset that blocks that (as VrForaging's does — it uses a `RELEASE_PAT`), we'll need to swap in a PAT secret. Flagging in case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)